### PR TITLE
fix(ktw): Status: unknown -> open on open-questions entries

### DIFF
--- a/context/open-questions.md
+++ b/context/open-questions.md
@@ -5,7 +5,8 @@ Found during a retrospective pass (2026-07) — genuinely unknown, not resolved 
 ## Uncapped retry loop on Binance error `-2010`
 
 **Type:** undefined — open question awaiting maintainer input, not yet classifiable as decision/workaround/incident/constraint
-**Status:** unknown — needs maintainer input
+**Status:** open — needs maintainer input
+**Evidence:** unknown
 
 `manager.py` (~lines 573-580), inside `create_stop_loss_order`: on Binance error code `-2010`, the code does `time.sleep(5)` and loops (`while order_is_placed is False`) with no retry cap — indefinite retry on a fixed 5-second interval. Other error codes `return False` immediately instead of retrying.
 
@@ -14,7 +15,8 @@ Found during a retrospective pass (2026-07) — genuinely unknown, not resolved 
 ## Why `jump-in-and-trail` is margin-only
 
 **Type:** undefined — open question awaiting maintainer input, not yet classifiable as decision/workaround/incident/constraint
-**Status:** unknown — needs maintainer input
+**Status:** open — needs maintainer input
+**Evidence:** unknown
 
 The `jump-in-and-trail` engine mode is described (README, `meta.yaml`) as "still experimental, only available for Isolated Margin." Commit history for it (`d1ef241`, `6b0942e`, `acb2c88`, etc.) has only terse subject lines ("jump-in-and-trail", "integration of smart entry") with no design rationale in the commit bodies.
 


### PR DESCRIPTION
Fixes `Status: unknown` on the open-questions entries — `unknown` is an Evidence level, not a valid Status value; `open` is the correct one for a genuinely unresolved question. Added the previously-missing separate `**Evidence:** unknown` line while at it, since it had been folded into the (wrong) Status text instead of its own field.

Follow-up to the keep-the-why context-schema 0.8.0 rollout, found while backfilling Type. Root-caused and documented upstream: oliver-zehentleitner/keep-the-why#157.